### PR TITLE
Added in windows support

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -23,15 +23,24 @@ module.exports = function resolve(dirname) {
 		}
 	});
 
-	// If the app-root-path library isn't loaded globally, 
+	// If the app-root-path library isn't loaded globally,
 	// and node_modules exists in the path, just split __dirname
-	if (!alternateMethod && -1 !== resolved.indexOf('/node_modules')) {
-		var parts = resolved.split('/node_modules');
-		if (parts.length) {
+	if( !alternateMethod ) {
+		var parts = undefined;
+		if (-1 !== resolved.indexOf('/node_modules')) {
+			parts = resolved.split('/node_modules');
+		} else if (-1 !== resolved.indexOf('\\node_modules')) {
+			//Check for Windows file systems if no forward slash
+			parts = resolved.split('\\node_modules');
+		}
+
+		if (parts && parts.length) {
 			appRootPath = parts[0];
 			parts = null;
 		}
 	}
+
+
 
 	// If the above didn't work, or this module is loaded globally, then
 	// resort to require.main.filename (See http://nodejs.org/api/modules.html)


### PR DESCRIPTION
Just changed the resolve parsing to look for \node_modules if it doesn't find /node_modules. That helps this work on Windows machines. Thanks for the library!
