### PR TITLE
Fix for usage with Electron renderer processes

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -39,6 +39,13 @@ module.exports = function resolve(dirname) {
 	if (alternateMethod || null == appRootPath) {
 		appRootPath = path.dirname(require.main.filename);
 	}
+	
+	// If this is an electron renderer process then get the root path of the
+	// main process instead
+	if (process && process.type === 'renderer') {
+		var remote = require('remote');
+		appRootPath = remote.require('app-root-path').path;
+	}
 
 	// Return
 	return appRootPath;


### PR DESCRIPTION
I'm not sure if this would be considered in-scope of the project but I added a conditional so that it works consistently with Electron.

Before this fix, if run in the Electron 'renderer' process then it would return the path for the dir containing the HTML file it is require'd on.
This is not what normally what you would want, this fix will use the app-root-path for the main process instead.

Probably not the most efficient way to implement this but it works for me.