### PR TITLE
Add support for relative imports

### DIFF
--- a/lib/app-root-path.js
+++ b/lib/app-root-path.js
@@ -10,6 +10,13 @@ module.exports = function(dirname) {
 			return path.join(appRootPath, pathToModule);
 		},
 
+		resolveRelative: function(pathToModule) {
+			if (!process.env.APP_RELATIVE_PATH) {
+				console.warn('APP_RELATIVE_PATH not defined!');
+			}
+			return publicInterface.resolve(path.join(process.env.APP_RELATIVE_PATH, pathToModule));
+		},
+
 		require: function(pathToModule) {
 			// Backwards compatibility check
 			if ('function' === typeof pathToModule) {
@@ -21,6 +28,10 @@ module.exports = function(dirname) {
 			}
 
 			return require(publicInterface.resolve(pathToModule));
+		},
+
+		requireRelative: function(pathToModule) {
+			return publicInterface.require(publicInterface.resolveRelative(pathToModule));
 		},
 
 		toString: function() {

--- a/lib/app-root-path.js
+++ b/lib/app-root-path.js
@@ -31,7 +31,10 @@ module.exports = function(dirname) {
 		},
 
 		requireRelative: function(pathToModule) {
-			return publicInterface.require(publicInterface.resolveRelative(pathToModule));
+			if (!process.env.APP_RELATIVE_PATH) {
+				console.warn('APP_RELATIVE_PATH not defined!');
+			}
+			return publicInterface.require(path.join(process.env.APP_RELATIVE_PATH, pathToModule));
 		},
 
 		toString: function() {


### PR DESCRIPTION
I often structure applications with a `source/` and `dist/` directory - being able to have code within each actually target the appropriate directory based on an environment variable is extremely useful.  However, it doesn't make sense for all resolves to go to those directories, as you wouldn't build configuration files from `source/` to `dist/` (they would likely be in `config/` or something similar instead).

This enables you to set `APP_RELATIVE_PATH`, which will be appended to whatever would have otherwise been resolved, and then use it with `resolveRelative` and `requireRelative`.

If you would like to include this please let me know and I will add the appropriate unit tests and make any necessary stylistic changes.