### PR TITLE
Update resolve.js

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -27,7 +27,7 @@ module.exports = function resolve(dirname) {
 
 	// Defer to main process in electron
 	if ('type' in process && 'renderer' === process.type) {
- 		var remote = require('remote');
+ 		var remote = require('electron').remote;
  		return remote.require('app-root-path').path;
 	}
 


### PR DESCRIPTION
Method of requiring has changed in electron since version 1.0. This change fixs the "Uncaught Error: Cannot find module 'remote'" error when trying to use "var appRoot = require('app-root-path');" on render side of an Electron app.