### PR TITLE
feat: Support AWS Lambda execution environment

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -32,6 +32,11 @@ module.exports = function resolve(dirname) {
 		return remote.require('app-root-path').path;
 	}
 
+	// Defer to AWS Lambda when executing there
+	if (process.env.LAMBDA_TASK_ROOT && process.env.AWS_EXECUTION_ENV) {
+		return process.env.LAMBDA_TASK_ROOT;
+	}
+
 	var resolved = path.resolve(dirname);
 	var alternateMethod = false;
 	var appRootPath = null;
@@ -46,7 +51,7 @@ module.exports = function resolve(dirname) {
 		}
 	});
 
-	// If the app-root-path library isn't loaded globally, 
+	// If the app-root-path library isn't loaded globally,
 	// and node_modules exists in the path, just split __dirname
 	var nodeModulesDir = sep + 'node_modules';
 	if (!alternateMethod && -1 !== resolved.indexOf(nodeModulesDir)) {

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,16 @@ describe('The path resolution method', function() {
 		delete global.window;
 		mockery.disable();
 	});
+
+	// Check AWS Lambda execution environment is honored
+	it('should respect the AWS Lambda environmental variables', function() {
+		var expected = '/some/arbirary/path';
+		process.env.LAMBDA_TASK_ROOT = expected;
+		process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodesomething';
+		assert.equal(resolve('/somewhere/else'), expected);
+		delete process.env.LAMBDA_TASK_ROOT;
+		delete process.env.AWS_EXECUTION_ENV;
+	});
 });
 
 describe('The public interface', function() {


### PR DESCRIPTION
AWS Lambda environment specifies LAMBDA_TASK_ROOT, which should be honored. Also check for the presence of AWS_EXECUTION_ENV for sanity.

AWS documentation: https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html