### PR TITLE
Fix webpack build issue

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -79,7 +79,7 @@ module.exports = function resolve(dirname) {
 	// If the above didn't work, or this module is loaded globally, then
 	// resort to require.main.filename (See http://nodejs.org/api/modules.html)
 	if (alternateMethod || null == appRootPath) {
-		appRootPath = path.dirname(require.main.filename);
+		appRootPath = path.dirname(requireFunction.main.filename);
 	}
 
 	// Handle global bin/ directory edge-case


### PR DESCRIPTION
When bundling with webpack, it throws an error on `path.dirname`, because `require.main` does not have a `filename`.