### PR TITLE
fix: #28

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -69,11 +69,21 @@ module.exports = function resolve(dirname) {
 	// and node_modules exists in the path, just split __dirname
 	var nodeModulesDir = sep + 'node_modules';
 	if (!alternateMethod && -1 !== resolved.indexOf(nodeModulesDir)) {
-		var parts = resolved.split(nodeModulesDir);
-		if (parts.length) {
-			appRootPath = parts[0];
-			parts = null;
-		}
+		// escape windows sep for reg
+		const sepInReg = path.sep.replace('\\', '\\\\');
+
+		const searchLastModulesReg = new RegExp(`(.*)${sepInReg}node_modules.*`);
+
+		// get string until before LAST node_modules, not FIRST. #28
+		appRootPath = resolved.replace(searchLastModulesReg, '$1');
+
+		// * ---------------- old logic // seognil LC 2019/07/03
+
+		// var parts = resolved.split(nodeModulesDir);
+		// if (parts.length) {
+		// 	appRootPath = parts[0];
+		// 	parts = null;
+		// }
 	}
 
 	// If the above didn't work, or this module is loaded globally, then


### PR DESCRIPTION
I meet the bug for my tool [la-starter-cli](https://github.com/seognil-lab/la-starter-cli/blob/master/src/utils/basic.js)

It seems the same as #28

## the error

For my case,  
`app-root-path` parse my tool's `appRoot` as `/usr/local/lib/` on Mac

So I got `/usr/local/lib/package.json` not found in my code

It should be `/usr/local/lib/node_modules/@seognil-lab/la-starter-cli/` instead

## the fix

I trace the code, it happens while there are multi `node_modules` in the path string

e.g. `/usr/local/lib/node_modules/@seognil-lab/la-starter-cli/node_modules/app-root-path/lib`

I update the code, and test manually passed for both **mac** and **window**

## remaining

But I'm not sure the origin logic,  
And I know `app-root-path` is used by tons of libs
So I also keep it as comment code,

Please check it
Thanks ~
