### PR TITLE
`resolve` function should behave as `path.resolve`

### DIFF
--- a/lib/app-root-path.js
+++ b/lib/app-root-path.js
@@ -7,7 +7,7 @@ module.exports = function(dirname) {
 
 	var publicInterface = {
 		resolve: function(pathToModule) {
-			return path.join(appRootPath, pathToModule);
+			return path.resolve(appRootPath, pathToModule);
 		},
 
 		require: function(pathToModule) {


### PR DESCRIPTION
I strongly believe `appRoot.resolve` should behave as `path.resolve` does.
It means:
- given relative path, resolve absolute path relative to the app root
- given absolute path, resolve given absolute path