### PR TITLE
feat: stop using `__dirname` if `APP_ROOT_PATH` is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
 var lib = require('./lib/app-root-path.js');
-module.exports = lib(__dirname);
+module.exports = lib(process.env.APP_ROOT_PATH || __dirname);


### PR DESCRIPTION
- it is not necessary to use __dirname if APP_ROOT_PATH env var is used.
- this should solve a problem when the package is used in an ESM app.