### PR TITLE
[fix] add support for esbuild

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -34,11 +34,14 @@ const isInstalledWithPNPM = function(resolved) {
 	return false;
 }
 
-const getFirstPartFromNodeModules = function(resolved) {
+const getFirstPart = function (resolved) {
 	const nodeModulesDir = sep + 'node_modules';
+	const esbuildDir = sep + '.esbuild';
 
-	if (-1 !== resolved.indexOf(nodeModulesDir)) {
-		const parts = resolved.split(nodeModulesDir);
+	const dirRegEx = new RegExp(`${nodeModulesDir}|${esbuildDir}`);
+
+	if (-1 !== resolved.indexOf(nodeModulesDir) || -1 !== resolved.indexOf(esbuildDir)) {
+		const parts = resolved.split(dirRegEx);
 		if (parts.length) {
 			return parts[0];
 		}
@@ -82,7 +85,7 @@ module.exports = function resolve(dirname) {
 	// Check if the globalPaths contain some folders with '.pnpm' in the path
 	// If yes this means it is most likely installed with pnpm
 	if (isInstalledWithPNPM(resolved)) {
-		appRootPath = getFirstPartFromNodeModules(resolved);
+		appRootPath = getFirstPart(resolved);
 
 		if (appRootPath) {
 			return appRootPath;
@@ -102,7 +105,7 @@ module.exports = function resolve(dirname) {
 	// If the app-root-path library isn't loaded globally,
 	// and node_modules exists in the path, just split __dirname
 	if (!alternateMethod) {
-		appRootPath = getFirstPartFromNodeModules(resolved);
+		appRootPath = getFirstPart(resolved);
 	}
 
 	// If the above didn't work, or this module is loaded globally, then


### PR DESCRIPTION
This may be related to #49 , but given the original ticket was not about esbuild, this is more related to one of the replies there.

I'm using `serverless-esbuild` / `serverless-offline` to run my code.

- the `resolved` variable in app-root-path's `resolve.js` is resolving to `'/my/path/to/project/.esbuild/.build/src'`
- the `appRootPath` is being returned as `'/my/path/to/project/node_modules/serverless-offline/src/lambda/handler-runner/worker-thread-runner'`
  - looks like appRootPath is being set for me in the else at the bottom: `appRootPath = path.dirname(process.argv[1]);`
- and what I want would be `/my/path/to/project/`

By changing `getFirstPartFromNodeModules` to `getFirstPart` and having it look for either node_modules or esbuild, it seems to solve this issue for me.

I thought about doing something like the following, if it would be preferred:
```
const getFirstPart = function (resolved) {
	const foldersToSplitOn = [
		'node_modules',
		'.esbuild'
	].map(folder => sep + folder);

	const dirRegEx = new RegExp(foldersToSplitOn.join('|'));

	if (foldersToSplitOn.some(folder => -1 !== resolved.indexOf(folder))) {
		const parts = resolved.split(dirRegEx);
		if (parts.length) {
			return parts[0];
		}
	}

    return null;
};
```